### PR TITLE
Fix conflict of Scheduler & Bootsrap

### DIFF
--- a/src/components/Scheduler/index.tsx
+++ b/src/components/Scheduler/index.tsx
@@ -93,7 +93,7 @@ const SchedulerComp = () => {
   }
 
   return (
-    <div className="bg-white p-2 rounded-lg">
+    <div className="bg-white p-2 rounded-lg rs_scheduler">
       <Scheduler
         events={events}
         view="week"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -82,3 +82,7 @@
   color: white;
   background: #9f6e0dd4;
 }
+
+.rs_scheduler .rs__cell {
+  box-sizing: content-box;
+}


### PR DESCRIPTION
Bootstrap forcing `box-sizing` rule that conflicts with `Scheduler` cells.
This PR fixes it

closes aldabil21/react-scheduler#236